### PR TITLE
Fix: Prevent 500 error for non-existent usernames in Digest authentic…

### DIFF
--- a/reverse_proxy/conf/nginx.conf
+++ b/reverse_proxy/conf/nginx.conf
@@ -81,7 +81,6 @@ http {
             proxy_pass $pass;
 
             # Digest認証のnonce作成のために作成
-            # etag on; # NOTE: ETagを有効にしてもproxy_passで転送するとETagがつかないのでsha256で代用
             set $secret_data "ZGMF-X42S";
 
             # キャッシュを無効にするためのヘッダーを設定


### PR DESCRIPTION
存在しないuserに対して500エラーになるバグを修正
